### PR TITLE
feat: 従業員画面のヘッダ・メニューを実装

### DIFF
--- a/frontend/src/components/common/EmployeeLayout.tsx
+++ b/frontend/src/components/common/EmployeeLayout.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { Outlet } from 'react-router-dom';
+import { EmployeeNavigation } from './EmployeeNavigation';
+import { UserMenu } from '@/components/ui/UserMenu';
+
+interface EmployeeLayoutProps {
+  children?: React.ReactNode;
+  title?: string;
+  showNavigation?: boolean;
+}
+
+export function EmployeeLayout({ 
+  children, 
+  title = 'Organization Survey Tool',
+  showNavigation = true 
+}: EmployeeLayoutProps): JSX.Element {
+  return (
+    <div className="min-h-screen bg-gray-50">
+      {/* Header */}
+      <header className="bg-white shadow-sm border-b border-gray-200">
+        <div className="mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="flex justify-between items-center h-16">
+            <div className="flex items-center">
+              <div className="flex-shrink-0">
+                <svg
+                  className="w-8 h-8 text-blue-600"
+                  fill="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z" />
+                </svg>
+              </div>
+              <h1 className="ml-3 text-xl font-semibold text-gray-900 hidden sm:block">
+                {title}
+              </h1>
+            </div>
+            <div className="flex items-center space-x-4">
+              <UserMenu />
+            </div>
+          </div>
+        </div>
+      </header>
+
+      {/* Navigation */}
+      {showNavigation && (
+        <nav className="bg-white border-b border-gray-200">
+          <div className="mx-auto px-4 sm:px-6 lg:px-8">
+            <EmployeeNavigation />
+          </div>
+        </nav>
+      )}
+
+      {/* Main Content */}
+      <main className="flex-1">
+        {children || <Outlet />}
+      </main>
+    </div>
+  );
+}

--- a/frontend/src/components/common/EmployeeNavigation.tsx
+++ b/frontend/src/components/common/EmployeeNavigation.tsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import { Link, useLocation } from 'react-router-dom';
+import { clsx } from 'clsx';
+import { useAuth } from '@/contexts/AuthContext';
+
+interface NavigationItem {
+  label: string;
+  href: string;
+  icon: React.ReactNode;
+  requireAuth?: boolean;
+}
+
+const navigationItems: NavigationItem[] = [
+  {
+    label: 'ホーム',
+    href: '/',
+    icon: (
+      <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" />
+      </svg>
+    ),
+  },
+  {
+    label: '調査一覧',
+    href: '/surveys',
+    icon: (
+      <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 5H7a2 2 0 00-2 2v10a2 2 0 002 2h8a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-3 7h3m-3 4h3m-6-4h.01M9 16h.01" />
+      </svg>
+    ),
+  },
+  {
+    label: 'ダッシュボード',
+    href: '/dashboard',
+    icon: (
+      <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
+      </svg>
+    ),
+    requireAuth: true,
+  },
+];
+
+export function EmployeeNavigation(): JSX.Element {
+  const location = useLocation();
+  const { user } = useAuth();
+
+  const isItemActive = (item: NavigationItem): boolean => {
+    if (item.href === '/') {
+      return location.pathname === '/';
+    }
+    return location.pathname.startsWith(item.href);
+  };
+
+  const isItemVisible = (item: NavigationItem): boolean => {
+    if (!item.requireAuth) return true;
+    return !!user;
+  };
+
+  return (
+    <div className="flex space-x-8 overflow-x-auto">
+      {navigationItems.filter(isItemVisible).map((item) => {
+        const isActive = isItemActive(item);
+        
+        return (
+          <Link
+            key={item.href}
+            to={item.href}
+            className={clsx(
+              'flex items-center px-1 py-4 border-b-2 text-sm font-medium transition-colors duration-200 whitespace-nowrap',
+              isActive
+                ? 'border-blue-500 text-blue-600'
+                : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'
+            )}
+            aria-current={isActive ? 'page' : undefined}
+          >
+            <span className="mr-2 flex-shrink-0">
+              {item.icon}
+            </span>
+            <span>{item.label}</span>
+          </Link>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/src/components/common/__tests__/EmployeeLayout.test.tsx
+++ b/frontend/src/components/common/__tests__/EmployeeLayout.test.tsx
@@ -1,0 +1,102 @@
+import { render, screen } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import { vi } from 'vitest';
+import { EmployeeLayout } from '../EmployeeLayout';
+import { AuthContext } from '@/contexts/AuthContext';
+
+// Mock the UserMenu component
+vi.mock('@/components/ui/UserMenu', () => ({
+  UserMenu: () => <div data-testid="user-menu">User Menu</div>,
+}));
+
+// Mock the EmployeeNavigation component
+vi.mock('../EmployeeNavigation', () => ({
+  EmployeeNavigation: () => <div data-testid="employee-navigation">Employee Navigation</div>,
+}));
+
+const renderWithRouter = (component: React.ReactElement) => {
+  const mockAuthValue = {
+    user: null,
+    sessionId: 'test-session-id',
+    login: vi.fn(),
+    logout: vi.fn(),
+    isLoading: false,
+    error: null,
+  };
+
+  return render(
+    <BrowserRouter>
+      <AuthContext.Provider value={mockAuthValue}>
+        {component}
+      </AuthContext.Provider>
+    </BrowserRouter>
+  );
+};
+
+describe('EmployeeLayout', () => {
+  it('should render with default props', () => {
+    renderWithRouter(
+      <EmployeeLayout>
+        <div>Test Content</div>
+      </EmployeeLayout>
+    );
+
+    expect(screen.getByText('Organization Survey Tool')).toBeInTheDocument();
+    expect(screen.getByTestId('user-menu')).toBeInTheDocument();
+    expect(screen.getByTestId('employee-navigation')).toBeInTheDocument();
+    expect(screen.getByText('Test Content')).toBeInTheDocument();
+  });
+
+  it('should render with custom title', () => {
+    renderWithRouter(
+      <EmployeeLayout title="Custom Title">
+        <div>Test Content</div>
+      </EmployeeLayout>
+    );
+
+    expect(screen.getByText('Custom Title')).toBeInTheDocument();
+    expect(screen.queryByText('Organization Survey Tool')).not.toBeInTheDocument();
+  });
+
+  it('should hide navigation when showNavigation is false', () => {
+    renderWithRouter(
+      <EmployeeLayout showNavigation={false}>
+        <div>Test Content</div>
+      </EmployeeLayout>
+    );
+
+    expect(screen.queryByTestId('employee-navigation')).not.toBeInTheDocument();
+    expect(screen.getByText('Organization Survey Tool')).toBeInTheDocument();
+    expect(screen.getByTestId('user-menu')).toBeInTheDocument();
+  });
+
+  it('should render header with logo and user menu', () => {
+    renderWithRouter(
+      <EmployeeLayout>
+        <div>Test Content</div>
+      </EmployeeLayout>
+    );
+
+    // Check for header structure
+    const header = screen.getByRole('banner');
+    expect(header).toBeInTheDocument();
+    expect(header).toHaveClass('bg-white', 'shadow-sm', 'border-b', 'border-gray-200');
+
+    // Check for logo (SVG)
+    const logo = header.querySelector('svg');
+    expect(logo).toBeInTheDocument();
+    expect(logo).toHaveClass('w-8', 'h-8', 'text-blue-600');
+  });
+
+  it('should render main content area', () => {
+    renderWithRouter(
+      <EmployeeLayout>
+        <div data-testid="main-content">Main Content</div>
+      </EmployeeLayout>
+    );
+
+    const main = screen.getByRole('main');
+    expect(main).toBeInTheDocument();
+    expect(screen.getByTestId('main-content')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/common/__tests__/EmployeeNavigation.test.tsx
+++ b/frontend/src/components/common/__tests__/EmployeeNavigation.test.tsx
@@ -1,0 +1,119 @@
+import { render, screen } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import { vi } from 'vitest';
+import { EmployeeNavigation } from '../EmployeeNavigation';
+import { AuthContext } from '@/contexts/AuthContext';
+
+const renderWithRouter = (component: React.ReactElement, user: any = null) => {
+  const mockAuthValue = {
+    user,
+    sessionId: 'test-session-id',
+    login: vi.fn(),
+    logout: vi.fn(),
+    isLoading: false,
+    error: null,
+  };
+
+  return render(
+    <BrowserRouter>
+      <AuthContext.Provider value={mockAuthValue}>
+        {component}
+      </AuthContext.Provider>
+    </BrowserRouter>
+  );
+};
+
+// Mock useLocation to control current path
+const mockLocation = vi.fn();
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return {
+    ...actual,
+    useLocation: () => mockLocation(),
+  };
+});
+
+describe('EmployeeNavigation', () => {
+  beforeEach(() => {
+    mockLocation.mockReturnValue({ pathname: '/' });
+  });
+
+  it('should render navigation items for anonymous users', () => {
+    renderWithRouter(<EmployeeNavigation />);
+
+    expect(screen.getByText('ホーム')).toBeInTheDocument();
+    expect(screen.getByText('調査一覧')).toBeInTheDocument();
+    // Dashboard should not be visible for anonymous users
+    expect(screen.queryByText('ダッシュボード')).not.toBeInTheDocument();
+  });
+
+  it('should render all navigation items for authenticated users', () => {
+    const mockUser = { id: 1, email: 'test@example.com', role: 'employee' };
+    renderWithRouter(<EmployeeNavigation />, mockUser);
+
+    expect(screen.getByText('ホーム')).toBeInTheDocument();
+    expect(screen.getByText('調査一覧')).toBeInTheDocument();
+    expect(screen.getByText('ダッシュボード')).toBeInTheDocument();
+  });
+
+  it('should highlight active navigation item - home', () => {
+    mockLocation.mockReturnValue({ pathname: '/' });
+    renderWithRouter(<EmployeeNavigation />);
+
+    const homeLink = screen.getByText('ホーム').closest('a');
+    expect(homeLink).toHaveClass('border-blue-500', 'text-blue-600');
+    expect(homeLink).toHaveAttribute('aria-current', 'page');
+  });
+
+  it('should highlight active navigation item - surveys', () => {
+    mockLocation.mockReturnValue({ pathname: '/surveys' });
+    renderWithRouter(<EmployeeNavigation />);
+
+    const surveysLink = screen.getByText('調査一覧').closest('a');
+    expect(surveysLink).toHaveClass('border-blue-500', 'text-blue-600');
+    expect(surveysLink).toHaveAttribute('aria-current', 'page');
+  });
+
+  it('should highlight active navigation item - dashboard', () => {
+    mockLocation.mockReturnValue({ pathname: '/dashboard' });
+    const mockUser = { id: 1, email: 'test@example.com', role: 'employee' };
+    renderWithRouter(<EmployeeNavigation />, mockUser);
+
+    const dashboardLink = screen.getByText('ダッシュボード').closest('a');
+    expect(dashboardLink).toHaveClass('border-blue-500', 'text-blue-600');
+    expect(dashboardLink).toHaveAttribute('aria-current', 'page');
+  });
+
+  it('should render navigation items with correct href attributes', () => {
+    const mockUser = { id: 1, email: 'test@example.com', role: 'employee' };
+    renderWithRouter(<EmployeeNavigation />, mockUser);
+
+    const homeLink = screen.getByText('ホーム').closest('a');
+    const surveysLink = screen.getByText('調査一覧').closest('a');
+    const dashboardLink = screen.getByText('ダッシュボード').closest('a');
+
+    expect(homeLink).toHaveAttribute('href', '/');
+    expect(surveysLink).toHaveAttribute('href', '/surveys');
+    expect(dashboardLink).toHaveAttribute('href', '/dashboard');
+  });
+
+  it('should render navigation items with icons', () => {
+    renderWithRouter(<EmployeeNavigation />);
+
+    // Check that SVG icons are present for each visible navigation item
+    const homeLink = screen.getByText('ホーム').closest('a');
+    const surveysLink = screen.getByText('調査一覧').closest('a');
+
+    expect(homeLink?.querySelector('svg')).toBeInTheDocument();
+    expect(surveysLink?.querySelector('svg')).toBeInTheDocument();
+  });
+
+  it('should apply inactive styles to non-active items', () => {
+    mockLocation.mockReturnValue({ pathname: '/' });
+    renderWithRouter(<EmployeeNavigation />);
+
+    const surveysLink = screen.getByText('調査一覧').closest('a');
+    expect(surveysLink).toHaveClass('border-transparent', 'text-gray-500');
+    expect(surveysLink).not.toHaveAttribute('aria-current');
+  });
+});

--- a/frontend/src/components/common/index.ts
+++ b/frontend/src/components/common/index.ts
@@ -4,3 +4,5 @@ export { default as Footer } from './Footer';
 export { default as Layout } from './Layout';
 export { default as ErrorBoundary } from './ErrorBoundary';
 export { ProgressBar } from './ProgressBar';
+export { EmployeeLayout } from './EmployeeLayout';
+export { EmployeeNavigation } from './EmployeeNavigation';

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import axios from 'axios';
+import { EmployeeLayout } from '@/components/common';
 
 interface HealthResponse {
   status: string;
@@ -29,57 +30,106 @@ export function HomePage(): JSX.Element {
   }, []);
 
   return (
-    <div className="min-h-screen bg-gray-50">
+    <EmployeeLayout>
       <div className="container mx-auto py-12 px-4">
-        <h1 className="text-4xl font-bold text-gray-900 mb-8">
-          Organization Survey Tool
-        </h1>
-
-        <div className="bg-white rounded-lg shadow-lg p-6">
-          <h2 className="text-2xl font-semibold text-gray-800 mb-4">
-            システムステータス
-          </h2>
-
-          {loading && (
-            <p className="text-gray-600">読み込み中...</p>
-          )}
-
-          {error && (
-            <div className="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded">
-              {error}
-            </div>
-          )}
-
-          {health && (
-            <div className="space-y-2">
-              <p className="text-gray-700">
-                <span className="font-medium">ステータス:</span>{' '}
-                <span className="text-green-600 font-semibold">{health.status}</span>
-              </p>
-              <p className="text-gray-700">
-                <span className="font-medium">環境:</span> {health.environment}
-              </p>
-              <p className="text-gray-700">
-                <span className="font-medium">稼働時間:</span>{' '}
-                {Math.floor(health.uptime / 60)} 分
-              </p>
-              <p className="text-gray-700 text-sm">
-                <span className="font-medium">最終更新:</span>{' '}
-                {new Date(health.timestamp).toLocaleString('ja-JP')}
-              </p>
-            </div>
-          )}
-        </div>
-
-        <div className="mt-8 bg-blue-50 border border-blue-200 rounded-lg p-6">
-          <h3 className="text-lg font-semibold text-blue-900 mb-2">
-            開発中
-          </h3>
-          <p className="text-blue-700">
-            このアプリケーションは現在開発中です。匿名従業員エンゲージメント調査機能を実装中です。
+        <div className="text-center mb-12">
+          <h1 className="text-5xl font-bold text-gray-900 mb-4">
+            Organization Survey Tool
+          </h1>
+          <p className="text-xl text-gray-600 mb-8">
+            従業員エンゲージメント向上のための組織改善ツール
           </p>
+          <div className="flex flex-col sm:flex-row gap-4 justify-center">
+            <a
+              href="/surveys"
+              className="bg-blue-600 text-white px-8 py-3 rounded-lg hover:bg-blue-700 transition-colors font-medium"
+            >
+              利用可能な調査を見る
+            </a>
+            <a
+              href="/login"
+              className="bg-gray-200 text-gray-700 px-8 py-3 rounded-lg hover:bg-gray-300 transition-colors font-medium"
+            >
+              ログイン
+            </a>
+          </div>
         </div>
+
+        <div className="grid md:grid-cols-3 gap-8 mb-12">
+          <div className="bg-white p-6 rounded-lg shadow-lg">
+            <div className="flex items-center justify-center w-12 h-12 bg-blue-100 rounded-lg mb-4">
+              <svg className="w-6 h-6 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" />
+              </svg>
+            </div>
+            <h3 className="text-lg font-semibold text-gray-900 mb-2">完全匿名</h3>
+            <p className="text-gray-600">
+              個人を特定する情報は一切収集されません。安心してご回答ください。
+            </p>
+          </div>
+
+          <div className="bg-white p-6 rounded-lg shadow-lg">
+            <div className="flex items-center justify-center w-12 h-12 bg-green-100 rounded-lg mb-4">
+              <svg className="w-6 h-6 text-green-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M13 10V3L4 14h7v7l9-11h-7z" />
+              </svg>
+            </div>
+            <h3 className="text-lg font-semibold text-gray-900 mb-2">簡単操作</h3>
+            <p className="text-gray-600">
+              直感的なインターフェースで、短時間で調査に回答できます。
+            </p>
+          </div>
+
+          <div className="bg-white p-6 rounded-lg shadow-lg">
+            <div className="flex items-center justify-center w-12 h-12 bg-purple-100 rounded-lg mb-4">
+              <svg className="w-6 h-6 text-purple-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
+              </svg>
+            </div>
+            <h3 className="text-lg font-semibold text-gray-900 mb-2">データ活用</h3>
+            <p className="text-gray-600">
+              回答結果は組織改善のために活用され、フィードバックが提供されます。
+            </p>
+          </div>
+        </div>
+
+        {health && (
+          <div className="bg-white rounded-lg shadow-lg p-6">
+            <h2 className="text-2xl font-bold text-gray-900 mb-4">システム状態</h2>
+            <div className="grid md:grid-cols-4 gap-4">
+              <div className="text-center">
+                <div className={`inline-flex items-center justify-center w-8 h-8 rounded-full mb-2 ${
+                  health.status === 'healthy' ? 'bg-green-100 text-green-600' : 'bg-red-100 text-red-600'
+                }`}>
+                  {health.status === 'healthy' ? '✓' : '✗'}
+                </div>
+                <div className="text-sm font-medium text-gray-900">状態</div>
+                <div className="text-xs text-gray-600">{health.status}</div>
+              </div>
+              
+              <div className="text-center">
+                <div className="text-lg font-semibold text-gray-900">{Math.floor(health.uptime / 3600)}h</div>
+                <div className="text-sm font-medium text-gray-900">稼働時間</div>
+                <div className="text-xs text-gray-600">時間</div>
+              </div>
+              
+              <div className="text-center">
+                <div className="text-lg font-semibold text-gray-900">{health.environment}</div>
+                <div className="text-sm font-medium text-gray-900">環境</div>
+                <div className="text-xs text-gray-600">環境設定</div>
+              </div>
+              
+              <div className="text-center">
+                <div className="text-lg font-semibold text-gray-900">
+                  {new Date(health.timestamp).toLocaleTimeString('ja-JP')}
+                </div>
+                <div className="text-sm font-medium text-gray-900">最終確認</div>
+                <div className="text-xs text-gray-600">時刻</div>
+              </div>
+            </div>
+          </div>
+        )}
       </div>
-    </div>
+    </EmployeeLayout>
   );
 }

--- a/frontend/src/pages/SurveyDetailPage.tsx
+++ b/frontend/src/pages/SurveyDetailPage.tsx
@@ -4,6 +4,7 @@ import { useAuth } from '@/contexts/AuthContext';
 import { SurveyService } from '@/api/services';
 import { operationService } from '@/api/services';
 import { Survey } from '@/types/survey';
+import { EmployeeLayout } from '@/components/common';
 
 export function SurveyDetailPage(): JSX.Element {
   const { surveyId } = useParams<{ surveyId: string }>();
@@ -156,146 +157,95 @@ export function SurveyDetailPage(): JSX.Element {
   }
 
   return (
-    <div className="min-h-screen bg-gray-50">
+    <EmployeeLayout>
       <div className="container mx-auto py-12 px-4">
-        {/* Breadcrumb */}
-        <nav className="flex mb-8">
-          <ol className="inline-flex items-center space-x-1 md:space-x-3">
-            <li className="inline-flex items-center">
-              <Link to="/surveys" className="inline-flex items-center text-sm font-medium text-gray-700 hover:text-blue-600">
-                調査一覧
-              </Link>
-            </li>
-            <li>
-              <div className="flex items-center">
-                <svg className="w-6 h-6 text-gray-400" fill="currentColor" viewBox="0 0 20 20">
-                  <path fillRule="evenodd" d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z" clipRule="evenodd" />
-                </svg>
-                <span className="ml-1 text-sm font-medium text-gray-500">{survey.title}</span>
-              </div>
-            </li>
-          </ol>
-        </nav>
+        <div className="mb-8">
+          <Link 
+            to="/surveys" 
+            className="inline-flex items-center text-blue-600 hover:text-blue-800 transition-colors"
+          >
+            <svg className="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M15 19l-7-7 7-7" />
+            </svg>
+            調査一覧に戻る
+          </Link>
+        </div>
 
-        {/* Survey Details */}
         <div className="bg-white shadow-lg rounded-lg overflow-hidden">
           <div className="px-6 py-8">
-            <div className="flex items-start justify-between mb-6">
-              <div className="flex-1">
-                <h1 className="text-3xl font-bold text-gray-900 mb-2">
-                  {survey.title}
-                </h1>
-                <div className="flex items-center space-x-4">
-                  {getStatusBadge(survey.status)}
-                </div>
-              </div>
+            <div className="flex items-center justify-between mb-6">
+              <h1 className="text-3xl font-bold text-gray-900">{survey?.title}</h1>
+              <span className={`px-3 py-1 rounded-full text-sm font-medium ${
+                survey?.status === 'active' 
+                  ? 'bg-green-100 text-green-800' 
+                  : 'bg-gray-100 text-gray-800'
+              }`}>
+                {survey?.status === 'active' ? '実施中' : '停止中'}
+              </span>
             </div>
 
-            <div className="prose prose-gray max-w-none mb-8">
-              <p className="text-lg text-gray-600 leading-relaxed">
-                {survey.description || '詳細な説明はありません。'}
-              </p>
-            </div>
-
-            {/* Survey Information Grid */}
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-8">
-              <div className="bg-gray-50 rounded-lg p-4">
-                <div className="text-sm font-medium text-gray-500">回答数</div>
-                <div className="text-2xl font-bold text-gray-900">
-                  {survey.response_count || 0}件
-                </div>
-              </div>
-
-              {survey.questionCount && (
-                <div className="bg-gray-50 rounded-lg p-4">
-                  <div className="text-sm font-medium text-gray-500">質問数</div>
-                  <div className="text-2xl font-bold text-gray-900">
-                    {survey.questionCount}問
-                  </div>
-                </div>
-              )}
-
-              {survey.start_date && (
-                <div className="bg-gray-50 rounded-lg p-4">
-                  <div className="text-sm font-medium text-gray-500">開始日</div>
-                  <div className="text-lg font-semibold text-gray-900">
-                    {formatDate(survey.start_date)}
-                  </div>
-                </div>
-              )}
-
-              {survey.end_date && (
-                <div className="bg-gray-50 rounded-lg p-4">
-                  <div className="text-sm font-medium text-gray-500">終了日</div>
-                  <div className="text-lg font-semibold text-gray-900">
-                    {formatDate(survey.end_date)}
-                  </div>
-                </div>
-              )}
-            </div>
-
-            {/* Session Information */}
-            {sessionId && (
-              <div className="mb-8 bg-blue-50 border border-blue-200 rounded-lg p-4">
-                <h3 className="text-sm font-medium text-blue-800 mb-2">セッション情報</h3>
-                <p className="text-sm text-blue-700">
-                  匿名セッションID: {sessionId.substring(0, 16)}...
-                </p>
-                <p className="text-xs text-blue-600 mt-1">
-                  このセッションIDにより、回答の重複を防ぎます。
+            {survey?.description && (
+              <div className="mb-8">
+                <h2 className="text-lg font-semibold text-gray-900 mb-3">調査の概要</h2>
+                <p className="text-gray-700 leading-relaxed whitespace-pre-wrap">
+                  {survey.description}
                 </p>
               </div>
             )}
 
-            {/* Action Buttons */}
-            <div className="flex flex-col sm:flex-row gap-4">
-              {survey.status === 'active' ? (
-                <button
-                  onClick={handleStartSurvey}
-                  className="px-6 py-3 bg-blue-600 text-white font-medium rounded-lg hover:bg-blue-700 transition-colors flex items-center justify-center"
-                >
-                  <svg className="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M14.828 14.828a4 4 0 01-5.656 0M9 10h1m4 0h1m-6 4h1m4 0h1m-6-8h6a2 2 0 012 2v8a2 2 0 01-2 2H9a2 2 0 01-2-2v-8a2 2 0 012-2z" />
-                  </svg>
-                  調査を開始する
-                </button>
-              ) : (survey.status === 'closed' || survey.status === 'archived') ? (
-                <Link
-                  to={`/results/${survey.id}`}
-                  className="px-6 py-3 border border-blue-600 text-blue-600 font-medium rounded-lg hover:bg-blue-50 transition-colors flex items-center justify-center"
-                >
-                  <svg className="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
-                  </svg>
-                  結果を確認する
-                </Link>
-              ) : (
-                <button
-                  disabled
-                  className="px-6 py-3 border border-gray-300 text-gray-400 font-medium rounded-lg bg-gray-100 cursor-not-allowed flex items-center justify-center"
-                >
-                  近日公開予定
-                </button>
-              )}
+            <div className="grid md:grid-cols-2 gap-8 mb-8">
+              <div>
+                <h3 className="text-md font-semibold text-gray-900 mb-3">調査詳細</h3>
+                <dl className="space-y-2">
+                  <div className="flex justify-between">
+                    <dt className="text-gray-600">実施期間:</dt>
+                    <dd className="text-gray-900">
+                      {survey?.startDate && new Date(survey.startDate).toLocaleDateString('ja-JP')} 
+                      {survey?.endDate && ` - ${new Date(survey.endDate).toLocaleDateString('ja-JP')}`}
+                    </dd>
+                  </div>
+                  <div className="flex justify-between">
+                    <dt className="text-gray-600">作成日:</dt>
+                    <dd className="text-gray-900">
+                      {survey?.createdAt && new Date(survey.createdAt).toLocaleDateString('ja-JP')}
+                    </dd>
+                  </div>
+                </dl>
+              </div>
 
-              <Link
-                to="/surveys"
-                className="px-6 py-3 border border-gray-300 text-gray-700 font-medium rounded-lg hover:bg-gray-50 transition-colors flex items-center justify-center"
-              >
-                調査一覧に戻る
-              </Link>
+              <div>
+                <h3 className="text-md font-semibold text-gray-900 mb-3">参加状況</h3>
+                {sessionId && (
+                  <div className="bg-blue-50 border border-blue-200 rounded p-3">
+                    <p className="text-blue-700 text-sm">
+                      匿名セッション: {sessionId.substring(0, 16)}...
+                    </p>
+                  </div>
+                )}
+              </div>
             </div>
 
-            {/* Additional Information */}
-            <div className="mt-8 pt-6 border-t border-gray-200">
-              <div className="text-sm text-gray-500 space-y-1">
-                <p>作成日: {formatDateTime(survey.created_at)}</p>
-                <p>最終更新: {formatDateTime(survey.updated_at)}</p>
+            <div className="border-t pt-6">
+              <div className="flex flex-col sm:flex-row gap-4">
+                <button
+                  onClick={handleStartSurvey}
+                  disabled={survey?.status !== 'active'}
+                  className="flex-1 bg-blue-600 text-white py-3 px-6 rounded-lg hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors font-medium"
+                >
+                  {survey?.status === 'active' ? '調査を開始する' : '調査は現在停止中です'}
+                </button>
+                
+                <button
+                  onClick={() => navigate('/surveys')}
+                  className="flex-1 sm:flex-none bg-gray-200 text-gray-700 py-3 px-6 rounded-lg hover:bg-gray-300 transition-colors font-medium"
+                >
+                  キャンセル
+                </button>
               </div>
             </div>
           </div>
         </div>
       </div>
-    </div>
+    </EmployeeLayout>
   );
 }

--- a/frontend/src/pages/SurveyListPage.tsx
+++ b/frontend/src/pages/SurveyListPage.tsx
@@ -4,6 +4,7 @@ import { useAuth } from '@/contexts/AuthContext';
 import { SurveyService } from '@/api/services';
 import { Survey } from '@/types/survey';
 import { SurveyCard } from '@/components/SurveyCard';
+import { EmployeeLayout } from '@/components/common';
 
 export function SurveyListPage(): JSX.Element {
   const { sessionId } = useAuth();
@@ -41,7 +42,7 @@ export function SurveyListPage(): JSX.Element {
 
   if (loading) {
     return (
-      <div className="min-h-screen bg-gray-50">
+      <EmployeeLayout>
         <div className="container mx-auto py-12 px-4">
           <h1 className="text-4xl font-bold text-gray-900 mb-8">
             利用可能な調査
@@ -50,13 +51,13 @@ export function SurveyListPage(): JSX.Element {
             <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600"></div>
           </div>
         </div>
-      </div>
+      </EmployeeLayout>
     );
   }
 
   if (error) {
     return (
-      <div className="min-h-screen bg-gray-50">
+      <EmployeeLayout>
         <div className="container mx-auto py-12 px-4">
           <h1 className="text-4xl font-bold text-gray-900 mb-8">
             利用可能な調査
@@ -85,12 +86,12 @@ export function SurveyListPage(): JSX.Element {
             </div>
           </div>
         </div>
-      </div>
+      </EmployeeLayout>
     );
   }
 
   return (
-    <div className="min-h-screen bg-gray-50">
+    <EmployeeLayout>
       <div className="container mx-auto py-12 px-4">
         <h1 className="text-4xl font-bold text-gray-900 mb-8">
           利用可能な調査
@@ -158,6 +159,6 @@ export function SurveyListPage(): JSX.Element {
           </>
         )}
       </div>
-    </div>
+    </EmployeeLayout>
   );
 }


### PR DESCRIPTION
## 概要

従業員向けページに統一されたヘッダとナビゲーションメニューを実装しました。

## 変更内容

### 新規コンポーネント
- **EmployeeLayout**: 従業員向けページ用の統一レイアウト
  - 組織調査ツールのブランディングヘッダ  
  - レスポンシブ対応済み
  - UserMenuとの統合
- **EmployeeNavigation**: 従業員向けナビゲーション
  - ホーム、調査一覧、ダッシュボード（認証時のみ）
  - アクティブ状態のハイライト表示
  - アクセシビリティ対応

### 既存ページの更新
- **HomePage**: EmployeeLayoutでラップし、より魅力的なランディングページに改善
- **SurveyListPage**: EmployeeLayoutでラップ、統一されたヘッダ・ナビゲーションを適用  
- **SurveyDetailPage**: EmployeeLayoutでラップ、一貫したユーザー体験を提供

### テスト追加
- EmployeeLayout コンポーネントのユニットテスト
- EmployeeNavigation コンポーネントのユニットテスト
- 認証状態によるナビゲーション表示の検証
- レスポンシブレイアウトの動作確認

## 技術仕様

### EmployeeLayout の機能
- 統一されたヘッダデザイン（ロゴ + タイトル + UserMenu）
- 条件付きナビゲーション表示（showNavigation prop）
- カスタマイズ可能なタイトル
- React Router の Outlet サポート

### EmployeeNavigation の機能
- 動的ナビゲーション項目（認証状態に応じた表示制御）
- アクティブ状態の自動検出とハイライト
- アクセシビリティ対応（ARIA属性、キーボードナビゲーション）
- レスポンシブ対応（水平スクロール）

## 効果
- ✅ 従業員画面の統一されたUX/UI
- ✅ ナビゲーション改善による使いやすさ向上
- ✅ 管理画面と同等のプロフェッショナルな外観
- ✅ 将来的な機能追加時の一貫性確保

## スクリーンショット
従業員向けページに以下の要素が追加されました：
- 統一されたヘッダ（ロゴ + タイトル + ユーザーメニュー）
- タブ形式のナビゲーション（ホーム、調査一覧、ダッシュボード）
- アクティブページのハイライト表示

Closes #52