### PR TITLE
fix: 調査運用APIエンドポイントに/apiプレフィックスを追加

### DIFF
--- a/frontend/src/api/services/operationService.ts
+++ b/frontend/src/api/services/operationService.ts
@@ -12,7 +12,7 @@ export const operationService = {
    */
   async startSurvey(surveyId: number): Promise<SurveyOperation> {
     const response = await apiClient.post<SurveyOperation>(
-      `/surveys/${surveyId}/start`
+      `/api/surveys/${surveyId}/start`
     );
     return response;
   },
@@ -22,7 +22,7 @@ export const operationService = {
    */
   async stopSurvey(surveyId: number): Promise<SurveyOperation> {
     const response = await apiClient.post<SurveyOperation>(
-      `/surveys/${surveyId}/stop`
+      `/api/surveys/${surveyId}/stop`
     );
     return response;
   },
@@ -32,7 +32,7 @@ export const operationService = {
    */
   async pauseSurvey(surveyId: number): Promise<SurveyOperation> {
     const response = await apiClient.post<SurveyOperation>(
-      `/surveys/${surveyId}/pause`
+      `/api/surveys/${surveyId}/pause`
     );
     return response;
   },
@@ -42,7 +42,7 @@ export const operationService = {
    */
   async resumeSurvey(surveyId: number): Promise<SurveyOperation> {
     const response = await apiClient.post<SurveyOperation>(
-      `/surveys/${surveyId}/resume`
+      `/api/surveys/${surveyId}/resume`
     );
     return response;
   },
@@ -52,7 +52,7 @@ export const operationService = {
    */
   async createReminder(reminder: ReminderSettings): Promise<ReminderSettings> {
     const response = await apiClient.post<ReminderSettings>(
-      `/surveys/${reminder.surveyId}/reminders`,
+      `/api/surveys/${reminder.surveyId}/reminders`,
       reminder
     );
     return response;
@@ -63,7 +63,7 @@ export const operationService = {
    */
   async getSurveyReminders(surveyId: number): Promise<ReminderSettings[]> {
     const response = await apiClient.get<ReminderSettings[]>(
-      `/surveys/${surveyId}/reminders`
+      `/api/surveys/${surveyId}/reminders`
     );
     return response;
   },
@@ -77,7 +77,7 @@ export const operationService = {
     data: Partial<ReminderSettings>
   ): Promise<ReminderSettings> {
     const response = await apiClient.put<ReminderSettings>(
-      `/surveys/${surveyId}/reminders/${reminderId}`,
+      `/api/surveys/${surveyId}/reminders/${reminderId}`,
       data
     );
     return response;
@@ -87,7 +87,7 @@ export const operationService = {
    * Delete a reminder
    */
   async deleteReminder(surveyId: number, reminderId: number): Promise<void> {
-    await apiClient.delete(`/surveys/${surveyId}/reminders/${reminderId}`);
+    await apiClient.delete(`/api/surveys/${surveyId}/reminders/${reminderId}`);
   },
 
   /**
@@ -95,7 +95,7 @@ export const operationService = {
    */
   async getParticipationStats(surveyId: number): Promise<ParticipationStats> {
     const response = await apiClient.get<ParticipationStats>(
-      `/surveys/${surveyId}/participation`
+      `/api/surveys/${surveyId}/participation`
     );
     return response;
   },
@@ -105,7 +105,7 @@ export const operationService = {
    */
   async getSurveyOperationLogs(surveyId: number): Promise<OperationLog[]> {
     const response = await apiClient.get<OperationLog[]>(
-      `/surveys/${surveyId}/logs`
+      `/api/surveys/${surveyId}/logs`
     );
     return response;
   },

--- a/frontend/src/api/services/questionService.ts
+++ b/frontend/src/api/services/questionService.ts
@@ -28,7 +28,7 @@ export const questionService = {
    * Get a single question by ID
    */
   async getQuestion(id: number): Promise<QuestionResponse> {
-    const response = await apiClient.get(`/questions/${id}`) as QuestionResponse;
+    const response = await apiClient.get(`/api/questions/${id}`) as QuestionResponse;
     return response;
   },
 
@@ -37,7 +37,7 @@ export const questionService = {
    */
   async createQuestion(data: CreateQuestionDto): Promise<QuestionResponse> {
     try {
-      const response = await apiClient.post('/questions', data) as QuestionResponse;
+      const response = await apiClient.post('/api/questions', data) as QuestionResponse;
       return response;
     } catch (error: any) {
       // If we get a 404, it might be a timing issue - retry once
@@ -46,7 +46,7 @@ export const questionService = {
         await new Promise(resolve => setTimeout(resolve, 500));
 
         try {
-          const response = await apiClient.post('/questions', data) as QuestionResponse;
+          const response = await apiClient.post('/api/questions', data) as QuestionResponse;
           console.log('Question creation succeeded on retry');
           return response;
         } catch (retryError) {
@@ -62,7 +62,7 @@ export const questionService = {
    * Update an existing question
    */
   async updateQuestion(id: number, data: UpdateQuestionDto): Promise<QuestionResponse> {
-    const response = await apiClient.put(`/questions/${id}`, data) as QuestionResponse;
+    const response = await apiClient.put(`/api/questions/${id}`, data) as QuestionResponse;
     return response;
   },
 
@@ -70,7 +70,7 @@ export const questionService = {
    * Delete a question
    */
   async deleteQuestion(id: number): Promise<void> {
-    await apiClient.delete(`/questions/${id}`);
+    await apiClient.delete(`/api/questions/${id}`);
   },
 
   /**


### PR DESCRIPTION
## 概要
調査運用管理画面で「調査を開始」ボタンを押下した際に発生していた404エラーを修正しました。

## 問題
フロントエンドのAPIサービスが `/surveys/:id/start` にリクエストを送信していましたが、バックエンドは `/api/surveys/:id/start` でルートを登録していたため、Vite proxyが正しく動作せず404エラーが発生していました。

## 修正内容

### operationService.ts
全10エンドポイントに `/api` プレフィックスを追加:
- ✅ startSurvey: `/surveys/:id/start` → `/api/surveys/:id/start`
- ✅ stopSurvey: `/surveys/:id/stop` → `/api/surveys/:id/stop`
- ✅ pauseSurvey: `/surveys/:id/pause` → `/api/surveys/:id/pause`
- ✅ resumeSurvey: `/surveys/:id/resume` → `/api/surveys/:id/resume`
- ✅ createReminder: `/surveys/:id/reminders` → `/api/surveys/:id/reminders`
- ✅ getSurveyReminders: 同上
- ✅ updateReminder: `/surveys/:id/reminders/:reminderId` → `/api/surveys/:id/reminders/:reminderId`
- ✅ deleteReminder: 同上
- ✅ getParticipationStats: `/surveys/:id/participation` → `/api/surveys/:id/participation`
- ✅ getSurveyOperationLogs: `/surveys/:id/logs` → `/api/surveys/:id/logs`

### questionService.ts
APIプレフィックスが欠落していた4エンドポイントを修正:
- ✅ getQuestion: `/questions/:id` → `/api/questions/:id`
- ✅ createQuestion: `/questions` → `/api/questions`
- ✅ updateQuestion: `/questions/:id` → `/api/questions/:id`
- ✅ deleteQuestion: 同上

## 影響範囲
- 調査の開始/停止/一時停止/再開機能
- リマインダー管理機能
- 参加統計取得機能
- 運用ログ取得機能
- 質問の取得/作成/更新/削除機能

## テスト
- ✅ 構文エラーがないことを確認
- ✅ git diffで全14エンドポイントの修正を確認
- ✅ バックエンドのルート登録は既に正しく実装済みであることを確認

## 検証方法
1. Docker環境を起動: `docker compose up --build`
2. 調査一覧画面で調査を選択
3. 「調査を開始」ボタンを押下
4. エラーが発生せず、ステータスが「active」に変更されることを確認
5. ブラウザコンソールで `/api/surveys/:id/start` へのリクエストが成功していることを確認

Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)